### PR TITLE
Macro code refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +143,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-types",
  "lazy_static",
+ "pretty_assertions",
  "trybuild",
 ]
 
@@ -358,6 +368,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -807,6 +823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +854,18 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/macros/src/caller.rs
+++ b/macros/src/caller.rs
@@ -1,8 +1,8 @@
-use crate::{contract::utils, parser::ContractTrait};
+use crate::{contract::utils, parser::CasperContract};
 use proc_macro2::TokenStream;
 use quote::{quote, TokenStreamExt};
 
-pub fn generate_struct(input: &ContractTrait) -> TokenStream {
+pub fn generate_struct(input: &CasperContract) -> TokenStream {
     let ident = &input.caller_ident;
     quote! {
       pub struct #ident {
@@ -19,7 +19,7 @@ pub fn generate_struct(input: &ContractTrait) -> TokenStream {
     }
 }
 
-pub fn generate_interface_impl(input: &ContractTrait) -> TokenStream {
+pub fn generate_interface_impl(input: &CasperContract) -> TokenStream {
     let ident = &input.ident;
     let caller_ident = &input.caller_ident;
     let methods = build_methods(input);
@@ -31,9 +31,9 @@ pub fn generate_interface_impl(input: &ContractTrait) -> TokenStream {
     }
 }
 
-fn build_methods(input: &ContractTrait) -> TokenStream {
+fn build_methods(input: &CasperContract) -> TokenStream {
     let mut stream = TokenStream::new();
-    stream.append_all(input.methods.iter().map(|method| {
+    stream.append_all(input.trait_methods.iter().map(|method| {
         let sig = &method.sig;
         let ident = &sig.ident;
         let args = utils::generate_method_args(method);

--- a/macros/src/caller.rs
+++ b/macros/src/caller.rs
@@ -2,7 +2,17 @@ use crate::{contract::utils, parser::CasperContract};
 use proc_macro2::TokenStream;
 use quote::{quote, TokenStreamExt};
 
-pub fn generate_struct(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContract) -> TokenStream {
+    let struct_stream = generate_struct(input);
+    let struct_impl_stream = generate_interface_impl(input);
+    quote! {
+      #struct_stream
+
+      #struct_impl_stream
+    }
+}
+
+fn generate_struct(input: &CasperContract) -> TokenStream {
     let ident = &input.caller_ident;
     quote! {
       pub struct #ident {
@@ -19,7 +29,7 @@ pub fn generate_struct(input: &CasperContract) -> TokenStream {
     }
 }
 
-pub fn generate_interface_impl(input: &CasperContract) -> TokenStream {
+fn generate_interface_impl(input: &CasperContract) -> TokenStream {
     let ident = &input.ident;
     let caller_ident = &input.caller_ident;
     let methods = build_methods(input);

--- a/macros/src/caller.rs
+++ b/macros/src/caller.rs
@@ -1,8 +1,8 @@
-use crate::{contract::utils, parser::CasperContract};
+use crate::{contract::utils, parser::CasperContractItem};
 use proc_macro2::TokenStream;
 use quote::{quote, TokenStreamExt};
 
-pub fn generate_code(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContractItem) -> TokenStream {
     let struct_stream = generate_struct(input);
     let struct_impl_stream = generate_interface_impl(input);
     quote! {
@@ -12,7 +12,7 @@ pub fn generate_code(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_struct(input: &CasperContract) -> TokenStream {
+fn generate_struct(input: &CasperContractItem) -> TokenStream {
     let ident = &input.caller_ident;
     quote! {
       pub struct #ident {
@@ -29,7 +29,7 @@ fn generate_struct(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_interface_impl(input: &CasperContract) -> TokenStream {
+fn generate_interface_impl(input: &CasperContractItem) -> TokenStream {
     let ident = &input.ident;
     let caller_ident = &input.caller_ident;
     let methods = build_methods(input);
@@ -41,7 +41,7 @@ fn generate_interface_impl(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn build_methods(input: &CasperContract) -> TokenStream {
+fn build_methods(input: &CasperContractItem) -> TokenStream {
     let mut stream = TokenStream::new();
     stream.append_all(input.trait_methods.iter().map(|method| {
         let sig = &method.sig;

--- a/macros/src/casper_contract.rs
+++ b/macros/src/casper_contract.rs
@@ -2,9 +2,9 @@ use convert_case::Casing;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, TokenStreamExt};
 
-use crate::{contract::utils, parser::CasperContract};
+use crate::{contract::utils, parser::CasperContractItem};
 
-pub fn generate_code(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContractItem) -> TokenStream {
     let macro_ident = format_ident!(
         "{}",
         &input
@@ -28,7 +28,7 @@ pub fn generate_code(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_install(contract: &CasperContract) -> TokenStream {
+fn generate_install(contract: &CasperContractItem) -> TokenStream {
     let contract_ident = &contract.contract_ident;
 
     quote! {
@@ -39,7 +39,7 @@ fn generate_install(contract: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_interface_methods(contract: &CasperContract) -> TokenStream {
+fn generate_interface_methods(contract: &CasperContractItem) -> TokenStream {
     let contract_ident = &contract.contract_ident;
     let contract_interface_ident = &contract.ident;
 

--- a/macros/src/casper_contract.rs
+++ b/macros/src/casper_contract.rs
@@ -2,9 +2,9 @@ use convert_case::Casing;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, TokenStreamExt};
 
-use crate::{contract::utils, parser::ContractTrait};
+use crate::{contract::utils, parser::CasperContract};
 
-pub fn generate_macro(input: &ContractTrait) -> TokenStream {
+pub fn generate_macro(input: &CasperContract) -> TokenStream {
     let macro_ident = format_ident!(
         "{}",
         &input
@@ -28,7 +28,7 @@ pub fn generate_macro(input: &ContractTrait) -> TokenStream {
     }
 }
 
-fn generate_install(contract: &ContractTrait) -> TokenStream {
+fn generate_install(contract: &CasperContract) -> TokenStream {
     let contract_ident = &contract.contract_ident;
 
     quote! {
@@ -39,12 +39,12 @@ fn generate_install(contract: &ContractTrait) -> TokenStream {
     }
 }
 
-fn generate_interface_methods(contract: &ContractTrait) -> TokenStream {
+fn generate_interface_methods(contract: &CasperContract) -> TokenStream {
     let contract_ident = &contract.contract_ident;
     let contract_interface_ident = &contract.ident;
 
     let mut methods = TokenStream::new();
-    methods.append_all(contract.methods.iter().map(|method| {
+    methods.append_all(contract.trait_methods.iter().map(|method| {
         let ident = &method.sig.ident;
         let (casper_args, punctuated_args) = utils::parse_casper_args(method);
 

--- a/macros/src/casper_contract.rs
+++ b/macros/src/casper_contract.rs
@@ -4,7 +4,7 @@ use quote::{format_ident, quote, TokenStreamExt};
 
 use crate::{contract::utils, parser::CasperContract};
 
-pub fn generate_macro(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContract) -> TokenStream {
     let macro_ident = format_ident!(
         "{}",
         &input

--- a/macros/src/casper_contract_interface.rs
+++ b/macros/src/casper_contract_interface.rs
@@ -6,32 +6,21 @@ use crate::contract;
 use crate::parser::CasperContract;
 use crate::{caller, contract_test};
 
-pub fn expand_casper_contract_interface(input: CasperContract) -> TokenStream {
-    let contract_install = contract::generate_install(&input);
-    let contract_entry_points = contract::generate_entry_points(&input);
-    let interface_trait = contract::interface::generate_trait(&input);
-    let caller_struct = caller::generate_struct(&input);
-    let caller_impl = caller::generate_interface_impl(&input);
-
-    let contract_test_impl = contract_test::generate_test_implementation(&input);
-    let contract_test_interface = contract_test::generate_test_interface(&input);
-
-    let contract_macro = casper_contract::generate_macro(&input);
+pub fn generate_code(input: CasperContract) -> TokenStream {
+    let contract_impl = contract::generate_code(&input);
+    let contract_interface_trait = contract::interface::generate_code(&input);
+    let caller = caller::generate_code(&input);
+    let contract_test = contract_test::generate_code(&input);
+    let contract_macro = casper_contract::generate_code(&input);
 
     quote! {
-      #contract_install
+      #contract_impl
 
-      #contract_entry_points
+      #contract_interface_trait
 
-      #interface_trait
+      #caller
 
-      #caller_struct
-
-      #caller_impl
-
-      #contract_test_impl
-
-      #contract_test_interface
+      #contract_test
 
       #contract_macro
     }

--- a/macros/src/casper_contract_interface.rs
+++ b/macros/src/casper_contract_interface.rs
@@ -3,10 +3,10 @@ use quote::quote;
 
 use crate::casper_contract;
 use crate::contract;
-use crate::parser::CasperContract;
+use crate::parser::CasperContractItem;
 use crate::{caller, contract_test};
 
-pub fn generate_code(input: CasperContract) -> TokenStream {
+pub fn generate_code(input: CasperContractItem) -> TokenStream {
     let contract_impl = contract::generate_code(&input);
     let contract_interface_trait = contract::interface::generate_code(&input);
     let caller = caller::generate_code(&input);

--- a/macros/src/casper_contract_interface.rs
+++ b/macros/src/casper_contract_interface.rs
@@ -3,10 +3,10 @@ use quote::quote;
 
 use crate::casper_contract;
 use crate::contract;
-use crate::parser::ContractTrait;
+use crate::parser::CasperContract;
 use crate::{caller, contract_test};
 
-pub fn expand_casper_contract_interface(input: ContractTrait) -> TokenStream {
+pub fn expand_casper_contract_interface(input: CasperContract) -> TokenStream {
     let contract_install = contract::generate_install(&input);
     let contract_entry_points = contract::generate_entry_points(&input);
     let interface_trait = contract::interface::generate_trait(&input);

--- a/macros/src/contract.rs
+++ b/macros/src/contract.rs
@@ -117,11 +117,10 @@ pub mod interface {
 }
 
 pub mod utils {
+    use crate::parser::ContractTrait;
     use proc_macro2::{Ident, Span, TokenStream};
     use quote::{format_ident, quote, TokenStreamExt};
     use syn::{punctuated::Punctuated, token, FnArg, Pat, Token, TraitItemMethod, Type, TypePath};
-
-    use crate::parser::ContractTrait;
 
     pub fn collect_type_paths(method: &TraitItemMethod) -> Vec<&TypePath> {
         method

--- a/macros/src/contract.rs
+++ b/macros/src/contract.rs
@@ -2,9 +2,9 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{quote, TokenStreamExt};
 use syn::TraitItemMethod;
 
-use crate::parser::CasperContract;
+use crate::parser::CasperContractItem;
 
-pub fn generate_code(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContractItem) -> TokenStream {
     let contract_install = generate_install(input);
     let contract_entry_points = generate_entry_points(input);
 
@@ -14,7 +14,7 @@ pub fn generate_code(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_install(input: &CasperContract) -> TokenStream {
+fn generate_install(input: &CasperContractItem) -> TokenStream {
     let contract_ident = &input.contract_ident;
     let caller_ident = &input.caller_ident;
     let package_hash = &input.package_hash;
@@ -39,7 +39,7 @@ fn generate_install(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_entry_points(contract_trait: &CasperContract) -> TokenStream {
+fn generate_entry_points(contract_trait: &CasperContractItem) -> TokenStream {
     let contract_ident = &contract_trait.contract_ident;
     let mut add_entry_points = TokenStream::new();
     add_entry_points.append_all(contract_trait.trait_methods.iter().map(build_entry_point));
@@ -108,11 +108,11 @@ fn build_params(method: &TraitItemMethod) -> TokenStream {
 }
 
 pub mod interface {
-    use super::CasperContract;
+    use super::CasperContractItem;
     use proc_macro2::TokenStream;
     use quote::{quote, TokenStreamExt};
 
-    pub fn generate_code(model: &CasperContract) -> TokenStream {
+    pub fn generate_code(model: &CasperContractItem) -> TokenStream {
         let id = &model.ident;
 
         let mut methods = TokenStream::new();
@@ -127,7 +127,7 @@ pub mod interface {
 }
 
 pub mod utils {
-    use crate::parser::CasperContract;
+    use crate::parser::CasperContractItem;
     use proc_macro2::{Ident, Span, TokenStream};
     use quote::{format_ident, quote, TokenStreamExt};
     use syn::{punctuated::Punctuated, token, FnArg, Pat, Token, TraitItemMethod, Type, TypePath};
@@ -199,7 +199,7 @@ pub mod utils {
     }
 
     pub fn find_method<'a>(
-        input: &'a CasperContract,
+        input: &'a CasperContractItem,
         method_name: &str,
     ) -> Option<&'a TraitItemMethod> {
         input

--- a/macros/src/contract.rs
+++ b/macros/src/contract.rs
@@ -2,9 +2,9 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{quote, TokenStreamExt};
 use syn::TraitItemMethod;
 
-use crate::parser::ContractTrait;
+use crate::parser::CasperContract;
 
-pub fn generate_install(input: &ContractTrait) -> TokenStream {
+pub fn generate_install(input: &CasperContract) -> TokenStream {
     let ident = &input.contract_ident;
     let caller_ident = &input.caller_ident;
     let package_hash = &input.package_hash;
@@ -29,9 +29,9 @@ pub fn generate_install(input: &ContractTrait) -> TokenStream {
     }
 }
 
-pub fn generate_entry_points(contract_trait: &ContractTrait) -> TokenStream {
+pub fn generate_entry_points(contract_trait: &CasperContract) -> TokenStream {
     let mut add_entry_points = TokenStream::new();
-    add_entry_points.append_all(contract_trait.methods.iter().map(create_entry_point));
+    add_entry_points.append_all(contract_trait.trait_methods.iter().map(create_entry_point));
     let contract_ident = &contract_trait.contract_ident;
 
     quote! {
@@ -98,15 +98,15 @@ fn build_params(method: &TraitItemMethod) -> TokenStream {
 }
 
 pub mod interface {
-    use super::ContractTrait;
+    use super::CasperContract;
     use proc_macro2::TokenStream;
     use quote::{quote, TokenStreamExt};
 
-    pub fn generate_trait(model: &ContractTrait) -> TokenStream {
+    pub fn generate_trait(model: &CasperContract) -> TokenStream {
         let id = &model.ident;
 
         let mut methods = TokenStream::new();
-        methods.append_all(&model.methods);
+        methods.append_all(&model.trait_methods);
 
         quote! {
             pub trait #id {
@@ -117,7 +117,7 @@ pub mod interface {
 }
 
 pub mod utils {
-    use crate::parser::ContractTrait;
+    use crate::parser::CasperContract;
     use proc_macro2::{Ident, Span, TokenStream};
     use quote::{format_ident, quote, TokenStreamExt};
     use syn::{punctuated::Punctuated, token, FnArg, Pat, Token, TraitItemMethod, Type, TypePath};
@@ -187,11 +187,11 @@ pub mod utils {
     }
 
     pub fn find_method<'a>(
-        input: &'a ContractTrait,
+        input: &'a CasperContract,
         method_name: &str,
     ) -> Option<&'a TraitItemMethod> {
         input
-            .methods
+            .trait_methods
             .iter()
             .find(|method| method.sig.ident == *method_name)
     }

--- a/macros/src/contract_test.rs
+++ b/macros/src/contract_test.rs
@@ -5,7 +5,17 @@ use quote::quote;
 use quote::TokenStreamExt;
 use syn::ReturnType;
 
-pub fn generate_test_implementation(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContract) -> TokenStream {
+    let contract_test_interface = generate_test_interface(input);
+    let contract_test_impl = generate_test_implementation(input);
+
+    quote! {
+        #contract_test_impl
+        #contract_test_interface
+    }
+}
+
+fn generate_test_implementation(input: &CasperContract) -> TokenStream {
     let contract_ident = &input.contract_ident;
     let contract_test_ident = &input.contract_test_ident;
     let args = utils::generate_empty_args();
@@ -52,7 +62,7 @@ pub fn generate_test_implementation(input: &CasperContract) -> TokenStream {
     }
 }
 
-pub fn generate_test_interface(input: &CasperContract) -> TokenStream {
+fn generate_test_interface(input: &CasperContract) -> TokenStream {
     let ident = &input.ident;
     let contract_test_ident = &input.contract_test_ident;
     let methods = build_methods(input);

--- a/macros/src/contract_test.rs
+++ b/macros/src/contract_test.rs
@@ -1,11 +1,11 @@
 use crate::contract::utils;
-use crate::parser::ContractTrait;
+use crate::parser::CasperContract;
 use proc_macro2::TokenStream;
 use quote::quote;
 use quote::TokenStreamExt;
 use syn::ReturnType;
 
-pub fn generate_test_implementation(input: &ContractTrait) -> TokenStream {
+pub fn generate_test_implementation(input: &CasperContract) -> TokenStream {
     let contract_ident = &input.contract_ident;
     let contract_test_ident = &input.contract_test_ident;
     let args = utils::generate_empty_args();
@@ -52,7 +52,7 @@ pub fn generate_test_implementation(input: &ContractTrait) -> TokenStream {
     }
 }
 
-pub fn generate_test_interface(input: &ContractTrait) -> TokenStream {
+pub fn generate_test_interface(input: &CasperContract) -> TokenStream {
     let ident = &input.ident;
     let contract_test_ident = &input.contract_test_ident;
     let methods = build_methods(input);
@@ -65,9 +65,9 @@ pub fn generate_test_interface(input: &ContractTrait) -> TokenStream {
     }
 }
 
-fn build_methods(input: &ContractTrait) -> TokenStream {
+fn build_methods(input: &CasperContract) -> TokenStream {
     let mut stream = TokenStream::new();
-    stream.append_all(input.methods.iter().map(|method| {
+    stream.append_all(input.trait_methods.iter().map(|method| {
         let sig = &method.sig;
         let ident = &sig.ident;
         let args = utils::generate_method_args(method);

--- a/macros/src/contract_test.rs
+++ b/macros/src/contract_test.rs
@@ -1,11 +1,11 @@
 use crate::contract::utils;
-use crate::parser::CasperContract;
+use crate::parser::CasperContractItem;
 use proc_macro2::TokenStream;
 use quote::quote;
 use quote::TokenStreamExt;
 use syn::ReturnType;
 
-pub fn generate_code(input: &CasperContract) -> TokenStream {
+pub fn generate_code(input: &CasperContractItem) -> TokenStream {
     let contract_test_interface = generate_test_interface(input);
     let contract_test_impl = generate_test_implementation(input);
 
@@ -15,7 +15,7 @@ pub fn generate_code(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_test_implementation(input: &CasperContract) -> TokenStream {
+fn generate_test_implementation(input: &CasperContractItem) -> TokenStream {
     let contract_ident = &input.contract_ident;
     let contract_test_ident = &input.contract_test_ident;
     let args = utils::generate_empty_args();
@@ -62,7 +62,7 @@ fn generate_test_implementation(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn generate_test_interface(input: &CasperContract) -> TokenStream {
+fn generate_test_interface(input: &CasperContractItem) -> TokenStream {
     let ident = &input.ident;
     let contract_test_ident = &input.contract_test_ident;
     let methods = build_methods(input);
@@ -75,7 +75,7 @@ fn generate_test_interface(input: &CasperContract) -> TokenStream {
     }
 }
 
-fn build_methods(input: &CasperContract) -> TokenStream {
+fn build_methods(input: &CasperContractItem) -> TokenStream {
     let mut stream = TokenStream::new();
     stream.append_all(input.trait_methods.iter().map(|method| {
         let sig = &method.sig;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 
-use parser::ContractTrait;
+use parser::CasperContract;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
@@ -21,6 +21,6 @@ pub fn derive_events(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn casper_contract_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as ContractTrait);
+    let input = parse_macro_input!(item as CasperContract);
     casper_contract_interface::expand_casper_contract_interface(input).into()
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -22,5 +22,5 @@ pub fn derive_events(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn casper_contract_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as CasperContract);
-    casper_contract_interface::expand_casper_contract_interface(input).into()
+    casper_contract_interface::generate_code(input).into()
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 
-use parser::CasperContract;
+use parser::CasperContractItem;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
@@ -21,6 +21,6 @@ pub fn derive_events(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn casper_contract_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as CasperContract);
+    let input = parse_macro_input!(item as CasperContractItem);
     casper_contract_interface::generate_code(input).into()
 }

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -5,7 +5,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::{braced, Token, TraitItemMethod};
 
 #[derive(Debug)]
-pub struct CasperContract {
+pub struct CasperContractItem {
     pub trait_token: Token![trait],
     pub trait_methods: Vec<TraitItemMethod>,
     pub ident: Ident,
@@ -16,7 +16,7 @@ pub struct CasperContract {
     pub wasm_file_name: String,
 }
 
-impl Parse for CasperContract {
+impl Parse for CasperContractItem {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let content;
 
@@ -41,7 +41,7 @@ impl Parse for CasperContract {
         let package_hash = format!("{}_package_hash", name.to_case(Case::Snake));
         let wasm_file_name = format!("{}.wasm", name.to_case(Case::Snake));
 
-        Ok(CasperContract {
+        Ok(CasperContractItem {
             trait_token,
             trait_methods: methods,
             ident,

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -5,18 +5,18 @@ use syn::parse::{Parse, ParseStream};
 use syn::{braced, Token, TraitItemMethod};
 
 #[derive(Debug)]
-pub struct ContractTrait {
+pub struct CasperContract {
     pub trait_token: Token![trait],
+    pub trait_methods: Vec<TraitItemMethod>,
     pub ident: Ident,
     pub contract_ident: Ident,
     pub caller_ident: Ident,
     pub contract_test_ident: Ident,
-    pub methods: Vec<TraitItemMethod>,
     pub package_hash: String,
     pub wasm_file_name: String,
 }
 
-impl Parse for ContractTrait {
+impl Parse for CasperContract {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let content;
 
@@ -41,13 +41,13 @@ impl Parse for ContractTrait {
         let package_hash = format!("{}_package_hash", name.to_case(Case::Snake));
         let wasm_file_name = format!("{}.wasm", name.to_case(Case::Snake));
 
-        Ok(ContractTrait {
+        Ok(CasperContract {
             trait_token,
+            trait_methods: methods,
             ident,
             contract_ident,
             caller_ident,
             contract_test_ident,
-            methods,
             package_hash,
             wasm_file_name,
         })

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,6 +14,7 @@ casper-execution-engine = { version = "1.4.4", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"
+pretty_assertions = "1.2.0"
 
 [[test]]
 name = "tests"

--- a/utils/sample-contract/src/contract.rs
+++ b/utils/sample-contract/src/contract.rs
@@ -6,6 +6,7 @@ pub trait ImportantContractInterface {
     fn init(&mut self, first_arg: casper_types::U256, second_arg: casper_types::U256);
     fn mint(&mut self, recipient: casper_dao_utils::Address, amount: casper_types::U256);
     fn balance_of(&mut self, to: casper_dao_utils::Address) -> casper_types::U256;
+    fn argless(&mut self);
 }
 
 #[derive(Default)]
@@ -19,4 +20,6 @@ impl ImportantContractInterface for ImportantContract {
     fn balance_of(&mut self, to: casper_dao_utils::Address) -> casper_types::U256 {
         casper_types::U256::default()
     }
+
+    fn argless(&mut self) {}
 }

--- a/utils/tests/macro_test.rs
+++ b/utils/tests/macro_test.rs
@@ -1,3 +1,4 @@
+use pretty_assertions::assert_eq;
 use std::{
     fs,
     process::{Command, Stdio},
@@ -21,7 +22,7 @@ fn check_casper_contract_interface_output() {
         &["expand", "--lib", "contract", "--features", "test-support"],
         "tests/templates/contract.template",
     );
-    assert_eq!(expansion, template);
+    assert_eq!(template, expansion);
 }
 
 #[test]
@@ -36,7 +37,7 @@ fn check_casper_contract_bin_output() {
         ],
         "tests/templates/bin.template",
     );
-    assert_eq!(expansion, template);
+    assert_eq!(template, expansion);
 }
 
 fn expand(cmd_args: &[&str], template_path: &str) -> (String, String) {

--- a/utils/tests/templates/bin.template
+++ b/utils/tests/templates/bin.template
@@ -29,3 +29,8 @@ fn balance_of() {
     let mut contract = ImportantContract::default();
     ImportantContractInterface::balance_of(&mut contract, to);
 }
+#[no_mangle]
+fn argless() {
+    let mut contract = ImportantContract::default();
+    ImportantContractInterface::argless(&mut contract);
+}

--- a/utils/tests/templates/contract.template
+++ b/utils/tests/templates/contract.template
@@ -72,6 +72,16 @@ mod contract {
                 casper_types::EntryPointAccess::Public,
                 casper_types::EntryPointType::Contract,
             ));
+            entry_points.add_entry_point(casper_types::EntryPoint::new(
+                "argless",
+                {
+                    let mut params: Vec<casper_types::Parameter> = Vec::new();
+                    params
+                },
+                <() as casper_types::CLTyped>::cl_type(),
+                casper_types::EntryPointAccess::Public,
+                casper_types::EntryPointType::Contract,
+            ));
             entry_points
         }
     }
@@ -79,6 +89,7 @@ mod contract {
         fn init(&mut self, first_arg: casper_types::U256, second_arg: casper_types::U256);
         fn mint(&mut self, recipient: casper_dao_utils::Address, amount: casper_types::U256);
         fn balance_of(&mut self, to: casper_dao_utils::Address) -> casper_types::U256;
+        fn argless(&mut self);
     }
     pub struct ImportantContractCaller {
         contract_package_hash: casper_types::ContractPackageHash,
@@ -129,6 +140,14 @@ mod contract {
                 },
             )
         }
+        fn argless(&mut self) {
+            casper_contract::contract_api::runtime::call_versioned_contract(
+                self.contract_package_hash,
+                std::option::Option::None,
+                "argless",
+                casper_types::RuntimeArgs::new(),
+            )
+        }
     }
     #[cfg(feature = "test-support")]
     pub struct ImportantContractTest {
@@ -139,10 +158,7 @@ mod contract {
     #[cfg(feature = "test-support")]
     impl ImportantContractTest {
         pub fn new(env: &casper_dao_utils::TestEnv) -> ImportantContractTest {
-            env.deploy_wasm_file("important_contract.wasm", {
-                let mut named_args = casper_types::RuntimeArgs::new();
-                named_args
-            });
+            env.deploy_wasm_file("important_contract.wasm", casper_types::RuntimeArgs::new());
             let package_hash = env.get_contract_package_hash("important_contract_package_hash");
             ImportantContractTest {
                 env: env.clone(),
@@ -215,6 +231,13 @@ mod contract {
                 });
             casper_types::U256::default()
         }
+        fn argless(&mut self) {
+            self.env.call_contract_package(
+                self.package_hash,
+                "argless",
+                casper_types::RuntimeArgs::new(),
+            );
+        }
     }
     pub struct ImportantContract {}
     #[automatically_derived]
@@ -231,5 +254,6 @@ mod contract {
         fn balance_of(&mut self, to: casper_dao_utils::Address) -> casper_types::U256 {
             casper_types::U256::default()
         }
+        fn argless(&mut self) {}
     }
 }


### PR DESCRIPTION
* unify naming of code generation methods
* rename ContractTrait struct to CasperContractItem
* update tests (test various methods: returning values, unit, taking args, argless, init with args)