### PR TITLE
Deploy to TestEnv with args

### DIFF
--- a/macros/src/contract.rs
+++ b/macros/src/contract.rs
@@ -192,12 +192,6 @@ pub mod utils {
         }
     }
 
-    pub fn generate_empty_args() -> TokenStream {
-        quote! {
-            casper_types::RuntimeArgs::new(),
-        }
-    }
-
     pub fn find_method<'a>(
         input: &'a CasperContractItem,
         method_name: &str,


### PR DESCRIPTION
* generate *ConractTest::new() with args from `init()` entry_point
* remove unused code
* generate `get_package_hash()` fn in *ContractTest