### PR TITLE
Passive reputation

### DIFF
--- a/dao-contracts/src/bid_escrow.rs
+++ b/dao-contracts/src/bid_escrow.rs
@@ -938,10 +938,18 @@ impl BidEscrowContract {
 
     fn mint_and_redistribute_reputation_for_external_worker(&mut self, job: &Job) {
         let configuration = self.get_job_offer_configuration(job);
-        let payment_reputation_to_mint =
-            configuration.apply_reputation_conversion_rate_to(job.payment());
-        let total = configuration.apply_default_policing_rate_to(payment_reputation_to_mint);
-        self.mint_reputation_for_voters(job, total);
+        let reputation_to_mint = configuration.apply_reputation_conversion_rate_to(job.payment());
+        let reputation_to_redistribute =
+            configuration.apply_default_policing_rate_to(reputation_to_mint);
+
+        // Worker
+        ReputationContractCaller::at(self.voting.reputation_token_address()).mint_passive(
+            job.worker(),
+            reputation_to_mint - reputation_to_redistribute,
+        );
+        
+        // Voters
+        self.mint_reputation_for_voters(job, reputation_to_redistribute);
     }
 
     fn mint_reputation_for_voters(&mut self, job: &Job, amount: U512) {

--- a/dao-contracts/src/kyc_nft.rs
+++ b/dao-contracts/src/kyc_nft.rs
@@ -8,7 +8,6 @@ use casper_dao_erc721::{
 };
 use casper_dao_modules::AccessControl;
 use casper_dao_utils::{
-    casper_contract::unwrap_or_revert::UnwrapOrRevert,
     casper_dao_macros::{casper_contract_interface, Instance},
     casper_env::{self, caller},
     Address,

--- a/dao-contracts/src/lib.rs
+++ b/dao-contracts/src/lib.rs
@@ -57,8 +57,12 @@ pub use rate_provider::{
 pub use repo_voter::RepoVoterContractTest;
 pub use repo_voter::{RepoVoterContract, RepoVoterContractCaller, RepoVoterContractInterface};
 #[cfg(feature = "test-support")]
-pub use reputation::ReputationContractTest;
-pub use reputation::{ReputationContract, ReputationContractCaller, ReputationContractInterface};
+pub use reputation::token::ReputationContractTest;
+pub use reputation::token::{
+    ReputationContract,
+    ReputationContractCaller,
+    ReputationContractInterface,
+};
 #[cfg(feature = "test-support")]
 pub use reputation_voter::ReputationVoterContractTest;
 pub use reputation_voter::{

--- a/dao-contracts/src/reputation/mod.rs
+++ b/dao-contracts/src/reputation/mod.rs
@@ -1,0 +1,2 @@
+mod passive_rep;
+pub mod token;

--- a/dao-contracts/src/reputation/passive_rep.rs
+++ b/dao-contracts/src/reputation/passive_rep.rs
@@ -38,6 +38,10 @@ impl PassiveReputation {
         self.set_balance(&owner, new_balance);
     }
 
+    pub fn balance_of(&self, address: Address) -> U512 {
+        self.balances.get(&address).unwrap_or_default()
+    }
+
     fn set_balance(&mut self, owner: &Address, new_balance: U512) {
         self.balances.set(owner, new_balance);
     }

--- a/dao-contracts/src/reputation/passive_rep.rs
+++ b/dao-contracts/src/reputation/passive_rep.rs
@@ -1,0 +1,44 @@
+use casper_dao_modules::AccessControl;
+use casper_dao_utils::{
+    casper_contract::unwrap_or_revert::UnwrapOrRevert,
+    casper_dao_macros::Instance,
+    Address,
+    Error,
+    Mapping,
+};
+use casper_types::U512;
+
+#[derive(Instance)]
+pub struct PassiveReputation {
+    balances: Mapping<Address, U512>,
+    #[scoped = "contract"]
+    pub access_control: AccessControl,
+}
+
+impl PassiveReputation {
+    pub fn mint(&mut self, recipient: Address, amount: U512) {
+        self.access_control.ensure_whitelisted();
+
+        let balance = self.balances.get(&recipient).unwrap_or_default();
+        let new_balance = balance
+            .checked_add(amount)
+            .unwrap_or_revert_with(Error::ArithmeticOverflow);
+
+        self.set_balance(&recipient, new_balance);
+    }
+
+    pub fn burn(&mut self, owner: Address, amount: U512) {
+        self.access_control.ensure_whitelisted();
+
+        let balance = self.balances.get(&owner).unwrap_or_default();
+        let new_balance = balance
+            .checked_sub(amount)
+            .unwrap_or_revert_with(Error::InsufficientBalance);
+
+        self.set_balance(&owner, new_balance);
+    }
+
+    fn set_balance(&mut self, owner: &Address, new_balance: U512) {
+        self.balances.set(owner, new_balance);
+    }
+}

--- a/dao-contracts/src/reputation/passive_rep.rs
+++ b/dao-contracts/src/reputation/passive_rep.rs
@@ -8,6 +8,11 @@ use casper_dao_utils::{
 };
 use casper_types::U512;
 
+/// The PassiveReputation module.
+///
+/// Stores information about potential balances of the users who are not eligible to have reputation tokens.
+/// If an Address owns a passive reputation, it means they have impacted the system (eg. have done a job). 
+/// These balances allow for keeping track of the total value of the system.
 #[derive(Instance)]
 pub struct PassiveReputation {
     balances: Mapping<Address, U512>,

--- a/dao-contracts/src/reputation/token.rs
+++ b/dao-contracts/src/reputation/token.rs
@@ -85,6 +85,8 @@ pub trait ReputationContractInterface {
     /// Returns the current token balance of the given address.
     fn balance_of(&self, address: Address) -> U512;
 
+    fn passive_balance_of(&self, address: Address) -> U512;
+
     /// Checks whether the given address is added to the whitelist.
     fn is_whitelisted(&self, address: Address) -> bool;
 
@@ -139,6 +141,8 @@ impl ReputationContractInterface for ReputationContract {
             fn mint_passive(&mut self, recipient: Address, amount: U512);
             #[call(burn)]
             fn burn_passive(&mut self, owner: Address, amount: U512);
+            #[call(balance_of)]
+            fn passive_balance_of(&self, address: Address) -> U512;
         }
     }
 

--- a/dao-contracts/src/reputation/token.rs
+++ b/dao-contracts/src/reputation/token.rs
@@ -38,7 +38,7 @@ pub trait ReputationContractInterface {
     fn init(&mut self);
 
     /// Mint new tokens. Add `amount` of new tokens to the balance of the `recipient` and
-    /// increment the total supply. Only whitelisted addresses are permited to call this method.
+    /// increment the total supply. Only whitelisted addresses are permitted to call this method.
     ///
     /// It throws [`NotWhitelisted`](casper_dao_utils::Error::NotWhitelisted) if caller
     /// is not whitelisted.
@@ -46,10 +46,14 @@ pub trait ReputationContractInterface {
     /// It emits [`Mint`](casper_dao_contracts::reputation::events::Mint) event.
     fn mint(&mut self, recipient: Address, amount: U512);
 
+    /// Increases the balance of the passive reputation of the given address.
+    ///
+    /// It throws [`NotWhitelisted`](casper_dao_utils::Error::NotWhitelisted) if caller
+    /// is not whitelisted.
     fn mint_passive(&mut self, recipient: Address, amount: U512);
 
     /// Burn existing tokens. Remove `amount` of existing tokens from the balance of the `owner`
-    /// and decrement the total supply. Only whitelisted addresses are permited to call this
+    /// and decrement the total supply. Only whitelisted addresses are permitted to call this
     /// method.
     ///
     /// It throws [`NotWhitelisted`](casper_dao_utils::Error::NotWhitelisted) if caller
@@ -58,10 +62,17 @@ pub trait ReputationContractInterface {
     /// It emits [`Burn`](casper_dao_contracts::reputation::events::Burn) event.
     fn burn(&mut self, owner: Address, amount: U512);
 
+    /// Decreases the balance of the passive reputation of the given address.
+    ///
+    /// It throws [`NotWhitelisted`](casper_dao_utils::Error::NotWhitelisted) if caller
+    /// is not whitelisted.
+    /// 
+    /// It throws [`InsufficientBalance`](casper_dao_utils::Error::InsufficientBalance) if the passed
+    /// amount exceeds the balance of the passive reputation of the given address.
     fn burn_passive(&mut self, owner: Address, amount: U512);
 
     /// Change ownership of the contract. Transfer the ownership to the `owner`. Only current owner
-    /// is permited to call this method.
+    /// is permitted to call this method.
     ///
     /// See [AccessControl](AccessControl::change_ownership())
     fn change_ownership(&mut self, owner: Address);
@@ -85,6 +96,7 @@ pub trait ReputationContractInterface {
     /// Returns the current token balance of the given address.
     fn balance_of(&self, address: Address) -> U512;
 
+    /// Returns the current passive balance of the given address.
     fn passive_balance_of(&self, address: Address) -> U512;
 
     /// Checks whether the given address is added to the whitelist.

--- a/dao-contracts/tests/common/dao/reputation.rs
+++ b/dao-contracts/tests/common/dao/reputation.rs
@@ -14,6 +14,12 @@ impl DaoWorld {
         Balance(balance)
     }
 
+    pub fn passive_reputation_balance(&self, account: &Account) -> Balance {
+        let address = self.get_address(account);
+        let balance = self.reputation_token.passive_balance_of(address);
+        Balance(balance)
+    }
+
     pub fn staked_reputation(&self, account: &Account) -> Balance {
         let address = self.get_address(account);
 
@@ -62,6 +68,18 @@ impl DaoWorld {
             "REP total supply should be {:?} but is {:?}",
             expected_balance,
             total_reputation
+        );
+    }
+
+    pub fn assert_passive_reputation(&self, account: &Account, expected_balance: Balance) {
+        let real_balance = self.passive_reputation_balance(account);
+        
+        assert!(
+            is_balance_close_enough(expected_balance, *real_balance),
+            "For account {:?} passive REP balance should be {:?} but is {:?}",
+            account,
+            expected_balance,
+            real_balance
         );
     }
 }

--- a/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker.feature
+++ b/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker.feature
@@ -76,5 +76,6 @@ Feature: External Worker who doesn't want to become a VA submits job
       | VA1              | 67.5         | 1507.5       | 0          |
       | VA2              | 22.72        | 507.5        | 0          |
       | BidEscrow        | 0            | 0            | 0          |
+    And passive REP of ExternalWorker is 35
     And total reputation is 3015
     And ExternalWorker is not a VA

--- a/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker_failed.feature
+++ b/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker_failed.feature
@@ -76,5 +76,6 @@ Feature: External Worker who doesn't want to become a VA submits job
       | VA1              | 150          | 1000         | 0          |
       | VA2              | 150          | 1000         | 0          |
       | BidEscrow        | 0            | 0            | 0          |
+    And passive REP of ExternalWorker is 0
     And total reputation is 3000
     And ExternalWorker is not a VA

--- a/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker_quorum_not_reached.feature
+++ b/dao-contracts/tests/features/bid_escrow/external_not_to_va_worker_quorum_not_reached.feature
@@ -66,5 +66,6 @@ Feature: External Worker who does not want to become a va - Quorum not reached
       | ExternalWorker   | 500          | 0            | 0          |
       | VA1              | 0            | 1000         | 0          |
       | VA2              | 0            | 1000         | 0          |
+    And passive REP of ExternalWorker is 0
     And total reputation is 6000
     And ExternalWorker is not a VA

--- a/dao-contracts/tests/steps/balances.rs
+++ b/dao-contracts/tests/steps/balances.rs
@@ -11,6 +11,11 @@ fn total_reputation(world: &mut DaoWorld, total_reputation_expected: Balance) {
     world.assert_total_supply(total_reputation_expected);
 }
 
+#[then(expr = "passive REP of {account} is {balance}")]
+fn assert_passive_reputation(world: &mut DaoWorld, account: Account, expected_balance: Balance) {
+    world.assert_passive_reputation(&account, expected_balance);
+}
+
 #[then(expr = "balances are")]
 #[then(expr = "users balances are")]
 fn assert_balances(world: &mut DaoWorld, step: &Step) {

--- a/dao-macros/src/instance.rs
+++ b/dao-macros/src/instance.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
+
 use proc_macro2::TokenStream;
-use quote::{quote, TokenStreamExt};
+use quote::quote;
 use syn::{spanned::Spanned, DataStruct, DeriveInput, Ident};
 
 pub fn generate_code(input: DeriveInput) -> TokenStream {
@@ -19,18 +21,60 @@ fn generate_or_err(input: DeriveInput) -> Result<TokenStream, syn::Error> {
 }
 
 fn parse_data(struct_ident: Ident, data_struct: DataStruct) -> Result<TokenStream, syn::Error> {
-    let mut fields = TokenStream::new();
-    fields.append_all(data_struct.fields.into_iter().map(|field| {
-        let ident = field.ident.unwrap();
-        quote! {
-            #ident: casper_dao_utils::instance::Instanced::instance(if namespace.is_empty() {
-                format!("{}", stringify!(#ident))
-            } else {
-                format!("{}_{}", stringify!(#ident), namespace)
+    let fields = data_struct
+        .fields
+        .into_iter()
+        .map(|field| {
+            let ident = field.ident.unwrap();
+
+            let scope = field
+                .attrs
+                .iter()
+                .filter(|attr| attr.path.is_ident("scoped"))
+                .find_map(|attr| match attr.parse_meta().unwrap() {
+                    syn::Meta::NameValue(name_value) => match name_value.lit {
+                        syn::Lit::Str(str) => {
+                            Some(str.value().parse::<Scope>().unwrap_or(Scope::Invalid))
+                        }
+                        _ => Some(Scope::Invalid),
+                    },
+                    _ => Some(Scope::Invalid),
+                })
+                .unwrap_or(Scope::None);
+
+            match scope {
+                Scope::Contract => Ok(quote! {
+                    #ident: casper_dao_utils::instance::Instanced::instance({
+                        let idx = namespace.rfind("__");
+                        let namespace = match idx {
+                            Some(value) => &namespace[value+2..],
+                            None => namespace
+                        };
+                        format!("{}__{}", stringify!(#ident), namespace).as_str()
+                    }),
+                }),
+                Scope::Parent => Ok(quote! {
+                    #ident: casper_dao_utils::instance::Instanced::instance({
+                        let idx = namespace.find("__");
+                        let namespace = match idx {
+                            Some(value) => &namespace[value+2..],
+                            None => namespace
+                        };
+                        format!("{}__{}", stringify!(#ident), namespace).as_str()
+                    }),
+                }),
+                Scope::None => Ok(quote! {
+                    #ident: casper_dao_utils::instance::Instanced::instance(
+                        format!("{}__{}", stringify!(#ident), namespace).as_str()
+                    ),
+                }),
+                Scope::Invalid => Err(syn::Error::new(
+                    ident.span(),
+                    "Invalid scope: available options are `contract` and `parent`",
+                )),
             }
-            .as_str()),
-        }
-    }));
+        })
+        .try_collect::<TokenStream>()?;
 
     Ok(quote! {
         impl casper_dao_utils::instance::Instanced for #struct_ident {
@@ -44,10 +88,31 @@ fn parse_data(struct_ident: Ident, data_struct: DataStruct) -> Result<TokenStrea
     })
 }
 
+#[derive(Debug, Clone, Copy)]
+enum Scope {
+    Contract,
+    Parent,
+    Invalid,
+    None,
+}
+
+impl FromStr for Scope {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "contract" => Self::Contract,
+            "parent" => Self::Parent,
+            _ => Self::None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use quote::quote;
     use syn::{
+        parse::Parser,
         punctuated::Punctuated,
         token,
         DataStruct,
@@ -55,9 +120,6 @@ mod tests {
         Fields,
         FieldsNamed,
         Token,
-        Type,
-        VisPublic,
-        Visibility,
     };
 
     use super::parse_data;
@@ -65,9 +127,16 @@ mod tests {
     #[test]
     fn parsing_struct_data_works() {
         let mut fields: Punctuated<Field, Token![,]> = Punctuated::new();
-        fields.push(create_field("b", syn::parse_quote! { B }));
-        fields.push(create_field("c", syn::parse_quote! { C }));
-        fields.push(create_field("d", syn::parse_quote! { D }));
+        fields.push(Field::parse_named.parse2(quote!(b: B)).unwrap());
+        fields.push(Field::parse_named.parse2(quote!(c: C)).unwrap());
+        fields.push(
+            Field::parse_named
+                .parse2(quote! {
+                    #[scoped = "parent"]
+                    d : D
+                })
+                .unwrap(),
+        );
         let input: DataStruct = build_struct(fields);
 
         let result = parse_data(quote::format_ident!("A"), input)
@@ -77,24 +146,20 @@ mod tests {
             impl casper_dao_utils::instance::Instanced for A {
                 fn instance(namespace: &str) -> Self {
                     Self {
-                        b: casper_dao_utils::instance::Instanced::instance(if namespace.is_empty() {
-                            format!("{}", stringify!(b))
-                        } else {
-                            format!("{}_{}", stringify!(b), namespace)
-                        }
-                        .as_str()),
-                        c: casper_dao_utils::instance::Instanced::instance(if namespace.is_empty() {
-                            format!("{}", stringify!(c))
-                        } else {
-                            format!("{}_{}", stringify!(c), namespace)
-                        }
-                        .as_str()),
-                        d: casper_dao_utils::instance::Instanced::instance(if namespace.is_empty() {
-                            format!("{}", stringify!(d))
-                        } else {
-                            format!("{}_{}", stringify!(d), namespace)
-                        }
-                        .as_str()),
+                        b: casper_dao_utils::instance::Instanced::instance(
+                            format!("{}__{}", stringify!(b), namespace).as_str()
+                        ),
+                        c: casper_dao_utils::instance::Instanced::instance(
+                            format!("{}__{}", stringify!(c), namespace).as_str()
+                        ),
+                        d: casper_dao_utils::instance::Instanced::instance({
+                            let idx = namespace.find("__");
+                            let namespace = match idx {
+                                Some(value) => &namespace[value+2..],
+                                None => namespace
+                            };
+                            format!("{}__{}", stringify!(d), namespace).as_str()
+                        }),
                     }
                 }
             }
@@ -104,16 +169,31 @@ mod tests {
         pretty_assertions::assert_eq!(expected, result);
     }
 
-    fn create_field(name: &str, ty: Type) -> Field {
-        Field {
-            attrs: vec![],
-            colon_token: Default::default(),
-            ident: Some(quote::format_ident!("{}", name)),
-            vis: Visibility::Public(VisPublic {
-                pub_token: Default::default(),
-            }),
-            ty,
-        }
+    #[test]
+    fn test_namespaces() {
+        let module = "access_control";
+
+        let parent_namespace = "token__contract";
+        let ident = format!("{}__{}", module, parent_namespace);
+        assert_eq!("access_control__token__contract", &ident);
+
+        let namespace = "variable_repository__token__contract";
+        let idx = namespace.find("__");
+        let namespace = match idx {
+            Some(value) => &namespace[value + 2..],
+            None => namespace,
+        };
+        let ident = format!("{}__{}", module, namespace);
+        assert_eq!("access_control__token__contract", &ident);
+
+        let namespace = "module__variable_repository__token__contract";
+        let idx = namespace.rfind("__");
+        let namespace = match idx {
+            Some(value) => &namespace[value + 2..],
+            None => namespace,
+        };
+        let ident = format!("{}__{}", module, namespace);
+        assert_eq!("access_control__contract", &ident);
     }
 
     fn build_struct(fields: Punctuated<Field, token::Comma>) -> DataStruct {

--- a/dao-macros/src/lib.rs
+++ b/dao-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iterator_try_collect)]
 extern crate proc_macro;
 
 use contract::CasperContractItem;
@@ -17,7 +18,7 @@ pub fn derive_events(input: TokenStream) -> TokenStream {
     event::expand_derive_events(input).into()
 }
 
-#[proc_macro_derive(Instance)]
+#[proc_macro_derive(Instance, attributes(scoped))]
 pub fn derive_instance(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     instance::generate_code(input).into()


### PR DESCRIPTION
Added:
`PassiveReputation` module
modules scoping
a module can be unscoped (default), or be in parent or contract scope.
Parent scope - module inherits the namespace of its parent
Contract scope - module inherits the namespace of the root (contract) module

Updated:
Test scenarios when an external worker does a job.
new entrypoints `mint_passive()`, `burn_passive`, `passive_balance_of()` in ReputationToken
